### PR TITLE
Add version flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /usr/src/k8s-rdma-shared-dp
 ENV HTTP_PROXY $http_proxy
 ENV HTTPS_PROXY $https_proxy
 
-RUN apk add --update --virtual build-dependencies build-base linux-headers && \
+RUN apk add --update --virtual build-dependencies build-base linux-headers git && \
     cd /usr/src/k8s-rdma-shared-dp && \
     make clean && \
     make build

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XT
 export GOPATH
 export GOBIN
 
+# Version
+VERSION?=master
+DATE=`date -Iseconds`
+COMMIT?=`git rev-parse --verify HEAD`
+LDFLAGS="-X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)"
+
 # Docker
 IMAGE_BUILDER?=@docker
 IMAGEDIR=$(BASE)/images
@@ -58,7 +64,7 @@ build: $(BUILDDIR)/$(BINARY_NAME) ; $(info Building $(BINARY_NAME)...) ## Build 
 	$(info Done!)
 
 $(BUILDDIR)/$(BINARY_NAME): $(GOFILES) | $(BUILDDIR)
-	@cd $(BASE)/cmd/$(BINARY_NAME) && CGO_ENABLED=0 $(GO) build -o $(BUILDDIR)/$(BINARY_NAME) -tags no_openssl -v
+	@cd $(BASE)/cmd/$(BINARY_NAME) && CGO_ENABLED=0 $(GO) build -o $(BUILDDIR)/$(BINARY_NAME) -tags no_openssl -ldflags $(LDFLAGS) -v
 
 # Tools
 $(GOLANGCI_LINT): | $(BASE) ; $(info  building golangci-lint...)

--- a/cmd/k8s-rdma-shared-dp/main.go
+++ b/cmd/k8s-rdma-shared-dp/main.go
@@ -1,18 +1,40 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
+	"os"
 	"syscall"
 
 	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/resources"
 )
 
-const (
-	rdmaSharedDpVersion = "0.2"
+var (
+	version = "master@git"
+	commit  = "unknown commit"
+	date    = "unknown date"
 )
 
+func printVersionString() string {
+	return fmt.Sprintf("k8s-rdma-shared-dev-plugin version:%s, commit:%s, date:%s", version, commit, date)
+}
+
 func main() {
-	log.Println("Starting K8s RDMA Shared Device Plugin version=", rdmaSharedDpVersion)
+	// Init command line flags to clear vendor packages' flags, especially in init()
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	// add version flag
+	versionOpt := false
+	flag.BoolVar(&versionOpt, "version", false, "Show application version")
+	flag.BoolVar(&versionOpt, "v", false, "Show application version")
+	flag.Parse()
+	if versionOpt {
+		fmt.Printf("%s\n", printVersionString())
+		return
+	}
+
+	log.Println("Starting K8s RDMA Shared Device Plugin version=", version)
 
 	rm := resources.NewResourceManager()
 


### PR DESCRIPTION
When run the k8s-rdma-shared-dev-plugin with flag -v or --version
it will show the branch of the build, commit id, and the build data
in the format: "k8s-rdma-shared-dev-plugin version:<branch>,
commit:<commit id>, date:<build-date>"