### PR TITLE
Changes the example pod image to mellanox/rping-test

### DIFF
--- a/example/test-hca-pod.yaml
+++ b/example/test-hca-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   restartPolicy: OnFailure
   containers:
-  - image: mellanox/centos_7_4_mofed_4_2_1_2_0_0_60
+  - image: mellanox/rping-test
     name: mofed-test-ctr
     securityContext:
       capabilities:

--- a/images/k8s-rdma-shared-dev-plugin-ds-pre-1.16.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds-pre-1.16.yaml
@@ -21,7 +21,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: rdma/k8s-rdma-shared-dev-plugin
+      - image: mellanox/k8s-rdma-shared-dev-plugin
         name: k8s-rdma-shared-dp-ds
         imagePullPolicy: IfNotPresent
         securityContext:

--- a/images/k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds.yaml
@@ -24,7 +24,7 @@ spec:
       - key: CriticalAddonsOnly
         operator: Exists
       containers:
-      - image: rdma/k8s-rdma-shared-dev-plugin
+      - image: mellanox/k8s-rdma-shared-dev-plugin
         name: k8s-rdma-shared-dp-ds
         imagePullPolicy: IfNotPresent
         securityContext:


### PR DESCRIPTION
Changed the example pod image from the mofed image to the mellanox
rping image. also changed the daemonsets images to take from the
mellanox repo, instead of the rdma repo.