### PR TITLE
Fix - device plugin server failed to restart correctly in legacy mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Mellanox/rdmamap v1.0.0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gogo/protobuf v1.3.1 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/jaypipes/ghw v0.6.1
 	github.com/jaypipes/pcidb v0.5.0
 	github.com/onsi/ginkgo v1.11.0

--- a/pkg/resources/resources_manager.go
+++ b/pkg/resources/resources_manager.go
@@ -153,11 +153,7 @@ func (rm *resourceManager) StartAllServers() error {
 
 		// start watcher
 		if !rm.watchMode {
-			go func() {
-				if err := rs.Watch(); err != nil {
-					log.Fatalf("Failed watching socket %v", err)
-				}
-			}()
+			go rs.Watch()
 		}
 	}
 	return nil

--- a/pkg/resources/watcher.go
+++ b/pkg/resources/watcher.go
@@ -5,8 +5,6 @@ import (
 	"os/signal"
 
 	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/types"
-
-	"github.com/fsnotify/fsnotify"
 )
 
 type signalNotifier struct {
@@ -18,23 +16,6 @@ func (n *signalNotifier) Notify() chan os.Signal {
 	signal.Notify(sigChan, n.signals...)
 
 	return sigChan
-}
-
-func newFSWatcher(files ...string) (*fsnotify.Watcher, error) {
-	watcher, err := fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, f := range files {
-		err = watcher.Add(f)
-		if err != nil {
-			watcher.Close()
-			return nil, err
-		}
-	}
-
-	return watcher, nil
 }
 
 // NewSignalNotifier return signals notifier

--- a/pkg/resources/watcher_test.go
+++ b/pkg/resources/watcher_test.go
@@ -3,8 +3,6 @@ package resources
 import (
 	"os"
 
-	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/utils"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -38,20 +36,6 @@ func (n *mockedSignalNotifier) triggerSignal(signal os.Signal) {
 }
 
 var _ = Describe("Watcher", func() {
-	Context("newFSWatcher", func() {
-		It("Watcher for existing Dir", func() {
-			fs := utils.FakeFilesystem{}
-			defer fs.Use()()
-			fsw, err := newFSWatcher(fs.RootDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fsw).ToNot(BeNil())
-		})
-		It("Watcher for non-existing Dir", func() {
-			fsw, err := newFSWatcher("fake")
-			Expect(err).To(HaveOccurred())
-			Expect(fsw).To(BeNil())
-		})
-	})
 	Context("NewOSWatcher", func() {
 		It("Watcher for signals", func() {
 			sn := mockedSignalNotifier{}

--- a/pkg/types/mocks/ResourceServer.go
+++ b/pkg/types/mocks/ResourceServer.go
@@ -138,15 +138,6 @@ func (_m *ResourceServer) Stop() error {
 }
 
 // Watch provides a mock function with given fields:
-func (_m *ResourceServer) Watch() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *ResourceServer) Watch() {
+	_m.Called()
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -38,7 +38,7 @@ type ResourceServer interface {
 	Start() error
 	Stop() error
 	Restart() error
-	Watch() error
+	Watch()
 }
 
 // ResourceManager manger multi plugins


### PR DESCRIPTION
When kubelet restart the server triggers restart which will be aborted
in the process because the function Watch that triggered the restart
will be stopped

This patch fix the issue of restartiing failure