### PR TITLE
Fail device plugin in case there are missing RDMA  devices

### DIFF
--- a/pkg/resources/pci_net_device.go
+++ b/pkg/resources/pci_net_device.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/jaypipes/ghw"
@@ -53,6 +54,9 @@ func NewPciNetDevice(dev *ghw.PCIDevice, rds types.RdmaDeviceSpec,
 	}
 
 	rdmaSpec := rds.Get(pciAddr)
+	if err := rds.VerifyRdmaSpec(rdmaSpec); err != nil {
+		return nil, fmt.Errorf("missing RDMA device spec for device %s, %v", pciAddr, err)
+	}
 
 	return &pciNetDevice{
 		pciAddress: pciAddr,

--- a/pkg/resources/rdma_device_spec.go
+++ b/pkg/resources/rdma_device_spec.go
@@ -1,12 +1,25 @@
 package resources
 
 import (
-	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/utils"
+	"fmt"
+	"path"
+	"strings"
 
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
+
+	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/types"
+	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/utils"
 )
 
 type rdmaDeviceSpec struct {
+	rdmaDevs []string
+}
+
+// Required RDMA devices
+var requiredRdmaDevices = []string{"issm", "rdma_cm", "umad", "uverbs"}
+
+func NewRdmaDeviceSpec(rdmaDevs []string) types.RdmaDeviceSpec {
+	return &rdmaDeviceSpec{rdmaDevs: rdmaDevs}
 }
 
 func (rf *rdmaDeviceSpec) Get(pciAddress string) []*pluginapi.DeviceSpec {
@@ -21,4 +34,25 @@ func (rf *rdmaDeviceSpec) Get(pciAddress string) []*pluginapi.DeviceSpec {
 	}
 
 	return deviceSpec
+}
+
+func (rf *rdmaDeviceSpec) VerifyRdmaSpec(rdmaDevSpecs []*pluginapi.DeviceSpec) error {
+	for _, rdmaDev := range rf.rdmaDevs {
+		if !containsRdmaDev(rdmaDevSpecs, rdmaDev) {
+			return fmt.Errorf("RDMA device %q not found", rdmaDev)
+		}
+	}
+
+	return nil
+}
+
+func containsRdmaDev(devSpecs []*pluginapi.DeviceSpec, rdmaDev string) bool {
+	for _, devSpec := range devSpecs {
+		_, devSpecName := path.Split(devSpec.HostPath)
+		if strings.Contains(devSpecName, rdmaDev) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/resources/resources_manager.go
+++ b/pkg/resources/resources_manager.go
@@ -42,6 +42,7 @@ type resourceManager struct {
 	resourceServers []types.ResourceServer
 	deviceList      []*ghw.PCIDevice
 	netlinkManager  types.NetlinkManager
+	rds             types.RdmaDeviceSpec
 }
 
 func NewResourceManager() types.ResourceManager {
@@ -57,6 +58,7 @@ func NewResourceManager() types.ResourceManager {
 		socketSuffix:   socketSuffix,
 		watchMode:      watcherMode,
 		netlinkManager: &netlinkManager{},
+		rds:            NewRdmaDeviceSpec(requiredRdmaDevices),
 	}
 }
 
@@ -230,9 +232,8 @@ func (rm *resourceManager) DiscoverHostDevices() error {
 
 func (rm *resourceManager) GetDevices() []types.PciNetDevice {
 	newPciDevices := make([]types.PciNetDevice, 0)
-	rds := &rdmaDeviceSpec{}
 	for _, device := range rm.deviceList {
-		if newDevice, err := NewPciNetDevice(device, rds, rm.netlinkManager); err == nil {
+		if newDevice, err := NewPciNetDevice(device, rm.rds, rm.netlinkManager); err == nil {
 			newPciDevices = append(newPciDevices, newDevice)
 		} else {
 			log.Printf("error creating new device: %q", err)

--- a/pkg/resources/resources_manager_test.go
+++ b/pkg/resources/resources_manager_test.go
@@ -15,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/mock"
 	"github.com/vishvananda/netlink"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 // FakeLink is a dummy netlink struct used during testing
@@ -246,6 +247,10 @@ var _ = Describe("ResourcesManger", func() {
 	})
 	Context("GetDevices", func() {
 		It("Get full list of devices", func() {
+			rds := &mocks.RdmaDeviceSpec{}
+			rds.On("Get", mock.Anything).Return([]*pluginapi.DeviceSpec{})
+			rds.On("VerifyRdmaSpec", mock.Anything).Return(nil)
+
 			fs := &utils.FakeFilesystem{
 				Dirs: []string{
 					"sys/bus/pci/devices/0000:02:00.0/net/enp2s0f0",
@@ -268,7 +273,7 @@ var _ = Describe("ResourcesManger", func() {
 			nLink := &mocks.NetlinkManager{}
 			link := &FakeLink{netlink.LinkAttrs{EncapType: "ether"}}
 			nLink.On("LinkByName", mock.Anything).Return(link, nil)
-			rm := &resourceManager{deviceList: deviceList, netlinkManager: nLink}
+			rm := &resourceManager{deviceList: deviceList, netlinkManager: nLink, rds: rds}
 			Expect(len(rm.GetDevices())).To(Equal(2))
 		})
 	})

--- a/pkg/types/mocks/RdmaDeviceSpec.go
+++ b/pkg/types/mocks/RdmaDeviceSpec.go
@@ -26,3 +26,17 @@ func (_m *RdmaDeviceSpec) Get(_a0 string) []*v1beta1.DeviceSpec {
 
 	return r0
 }
+
+// VerifyRdmaSpec provides a mock function with given fields: _a0
+func (_m *RdmaDeviceSpec) VerifyRdmaSpec(_a0 []*v1beta1.DeviceSpec) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func([]*v1beta1.DeviceSpec) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -75,6 +75,7 @@ type SignalNotifier interface {
 // RdmaDeviceSpec used to find the rdma devices
 type RdmaDeviceSpec interface {
 	Get(string) []*pluginapi.DeviceSpec
+	VerifyRdmaSpec([]*pluginapi.DeviceSpec) error
 }
 
 // PciNetDevice provides an interface to get generic device specific information


### PR DESCRIPTION
When run device plugin while booting and modules are not fully
loaded device plugin is missing RDMA devices which causes unwanted
behaviour for the device plugin consumers.

This change causes the device plugin to fail in case there are
missing RDMA devices