### PR TITLE
Add config field for periodic update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The plugin has several configuration fields, this section explains each field us
 
 ```json
 {
+  "periodicUpdateInterval": 300,
   "configList": [{
     "resourceName": "hca_shared_devices_a",
     "rdmaHcaMax": 1000,
@@ -96,6 +97,11 @@ The plugin has several configuration fields, this section explains each field us
   ]
 }
 ```
+
+`periodicUpdateInterval` is the time interval in seconds to update the resources according to host devices in case of changes.
+Notes:
+  - if `periodicUpdateInterval` is 0 then periodic update for host devices will be disabled.
+  - if `periodicUpdateInterval` is not set then default periodic update interval of 60 seconds will be used.
 
 `"configList"` should contain a list of config objects. Each config object may consist of following fields:
 

--- a/cmd/k8s-rdma-shared-dp/main.go
+++ b/cmd/k8s-rdma-shared-dp/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"syscall"
-	"time"
 
 	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/resources"
 )
@@ -16,9 +15,6 @@ var (
 	commit  = "unknown commit"
 	date    = "unknown date"
 )
-
-// Periodic Update interval
-const periodicUpdateInterval = 60 * time.Second
 
 func printVersionString() string {
 	return fmt.Sprintf("k8s-rdma-shared-dev-plugin version:%s, commit:%s, date:%s", version, commit, date)
@@ -40,7 +36,7 @@ func main() {
 
 	log.Println("Starting K8s RDMA Shared Device Plugin version=", version)
 
-	rm := resources.NewResourceManager(periodicUpdateInterval)
+	rm := resources.NewResourceManager()
 
 	log.Println("resource manager reading configs")
 	if err := rm.ReadConfig(); err != nil {

--- a/images/k8s-rdma-shared-dev-plugin-config-map.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-config-map.yaml
@@ -6,6 +6,7 @@ metadata:
 data:
   config.json: |
     {
+        "periodicUpdateInterval": 300,
         "configList": [{
              "resourceName": "hca_shared_devices_a",
              "rdmaHcaMax": 1000,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -29,7 +29,8 @@ type UserConfig struct {
 
 // UserConfigList config list for servers
 type UserConfigList struct {
-	ConfigList []UserConfig `json:"configList"`
+	PeriodicUpdateInterval *int         `json:"periodicUpdateInterval"`
+	ConfigList             []UserConfig `json:"configList"`
 }
 
 // ResourceServer is gRPC server implements K8s device plugin api


### PR DESCRIPTION
This change brings a new config field which is used to config the periodic update interval of the device plugin.
When periodic update interval is 0 periodic update is disabled

Fixes #27 