### PR TITLE
Mount /dev/inside rdma shared device plugin

### DIFF
--- a/images/k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds.yaml
@@ -34,6 +34,8 @@ spec:
             mountPath: /var/lib/kubelet/
           - name: config
             mountPath: /k8s-rdma-shared-dev-plugin
+          - name: devs
+            mountPath: /dev/
       volumes:
         - name: device-plugin
           hostPath:
@@ -44,3 +46,6 @@ spec:
             items:
             - key: config.json
               path: config.json
+        - name: devs
+          hostPath:
+            path: /dev/


### PR DESCRIPTION
Currently rdma resources "/dev/infiniband" are mounted by using
hostNetwork, where rdma resources will not be tracked when kernel
modules/drivers are installed after deploying rdma shared device
plugin.

This patch mounts "/dev/" inside the container with
volumes which keeps tracking the changes to devices changes,
mounting "/dev/" not "/dev/infiniband" because mounted dev dir
will be broken when dir is deleted, "/dev/infiniband" is deleted
when rdma modules unloaded