### PR TITLE
Validate RDMA subsystem network namespace mode on startup

### DIFF
--- a/cmd/k8s-rdma-shared-dp/main.go
+++ b/cmd/k8s-rdma-shared-dp/main.go
@@ -47,6 +47,10 @@ func main() {
 		log.Fatalf("Exiting.. one or more invalid configuration(s) given: %v", err)
 	}
 
+	if err := rm.ValidateRdmaSystemMode(); err != nil {
+		log.Fatalf("Exiting.. can not change : %v", err)
+	}
+
 	log.Println("Discovering host devices")
 	if err := rm.DiscoverHostDevices(); err != nil {
 		log.Fatalf("Error: error discovering host devices %v \n", err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -47,6 +47,7 @@ type ResourceServer interface {
 type ResourceManager interface {
 	ReadConfig() error
 	ValidateConfigs() error
+	ValidateRdmaSystemMode() error
 	DiscoverHostDevices() error
 	GetDevices() []PciNetDevice
 	InitServers() error


### PR DESCRIPTION
We support only shared mode for RDMA subsystem [1]. This patch
checks the current mode and tries to change it to the 'shared'.

[1] https://man7.org/linux/man-pages/man8/rdma-system.8.html

Closes: #6
Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>