### PR TITLE
Install kmod package in images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --update --virtual build-dependencies build-base linux-headers git &
     make build
 
 FROM ${BASE_IMAGE}
-RUN apk add hwdata-pci
+RUN apk add kmod hwdata-pci
 COPY --from=builder /usr/src/k8s-rdma-shared-dp/build/k8s-rdma-shared-dp /bin/
 
 LABEL io.k8s.display-name="RDMA Shared Device Plugin"

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -13,7 +13,7 @@ RUN apk add --update --virtual build-dependencies build-base linux-headers git &
     make build
 
 FROM ${BASE_IMAGE}
-RUN microdnf install hwdata
+RUN microdnf install kmod hwdata
 COPY --from=builder /usr/src/k8s-rdma-shared-dp/build/k8s-rdma-shared-dp /bin/
 
 LABEL io.k8s.display-name="RDMA Shared Device Plugin"


### PR DESCRIPTION
The latest Alpine and UBI-miminal don't contain kmod installed so
Network Operator failes to run init container.