### PR TITLE
Update base Alpine image to 3.14.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.14.0
+ARG BASE_IMAGE=alpine:3.14.3
 FROM golang:alpine as builder
 
 ADD . /usr/src/k8s-rdma-shared-dp


### PR DESCRIPTION
This patch will fix CVEs in following packages:
* libssl1.1 - CVE-2021-3711 - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711
* libssl1.1 - CVE-2021-3712 - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712
* libcrypto1.1 - CVE-2021-3712 - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3712
* apk-tools - CVE-2021-36159 - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36159
* libcrypto1.1 - CVE-2021-3711 - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711

Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>