### PR TITLE
Add note to build image with newer Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,7 @@ docker build -t k8s-rdma-shared-dev-plugin \
 --build-arg BASE_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:latest \
 .
 ```
+
+> __Note:__ Building image with alpine v3.14.x requires Docker 20.10.0 or newer. for more information refer to
+[Alpine 3.14.0 Release Notes](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2)
+


### PR DESCRIPTION
Currently latest alpine image points to v3.14.0.
Building image with docker older than 20.10.0 will
cause image build to fail with:

`make: /bin/sh: Operation not permitted`

More info can be found in alpine release notes:
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2

Add a note to build image with Docker 20.10.0 or newer.

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>