### PR TITLE
Set priorityClassName instead of annotation

### DIFF
--- a/images/k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds.yaml
@@ -9,20 +9,11 @@ spec:
       name: rdma-shared-dp-ds
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: rdma-shared-dp-ds
     spec:
       hostNetwork: true
-      tolerations:
-      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-      # This, along with the annotation above marks this pod as a critical add-on.
-      - key: CriticalAddonsOnly
-        operator: Exists
+      priorityClassName: system-node-critical
       containers:
       - image: mellanox/k8s-rdma-shared-dev-plugin
         name: k8s-rdma-shared-dp-ds


### PR DESCRIPTION
scheduler.alpha.kubernetes.io is deprecated in k8s v1.16+.
This emits a warning when deploying components which have
this annotation:

Warning: spec.template.metadata.annotations
[scheduler.alpha.kubernetes.io/critical-pod]: non-functional in v1.16+;
use the "priorityClassName" field instead

Signed-off-by: Fred Rolland <frolland@nvidia.com>