### PR TITLE
Update base image to alpine:3.15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=alpine:3.14.3
+ARG BASE_IMAGE=alpine:3.15.4
 FROM golang:alpine as builder
 
 ADD . /usr/src/k8s-rdma-shared-dp


### PR DESCRIPTION
This patch fixes following CVEs:

* https://nvd.nist.gov/vuln/detail/CVE-2022-0778
* https://nvd.nist.gov/vuln/detail/CVE-2018-25032
* https://nvd.nist.gov/vuln/detail/CVE-2022-0778

Signed-off-by: Ivan Kolodiazhny <ikolodiazhny@nvidia.com>