### PR TITLE
Makefile refactors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18.x'
+          go-version: '1.20.x'
       - name: checkout
         uses: actions/checkout@v3
       - name: lint


### PR DESCRIPTION
- use go install to install relevant binaries
- dont use .gopath as alternate GOPATH, rely on
  go modules doing its job
- remove BASE var as its not longer needed

Signed-off-by: adrianc <adrianc@nvidia.com>