### PR TITLE
Update device plugins volumes mounts

### DIFF
--- a/images/k8s-rdma-shared-dev-plugin-ds-pre-1.16.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds-pre-1.16.yaml
@@ -28,13 +28,20 @@ spec:
           privileged: true
         volumeMounts:
           - name: device-plugin
-            mountPath: /var/lib/kubelet/
+            mountPath: /var/lib/kubelet/device-plugins
+            readOnly: false
+          - name: plugins-registry
+            mountPath: /var/lib/kubelet/plugins_registry
+            readOnly: false
           - name: config
             mountPath: /k8s-rdma-shared-dev-plugin
       volumes:
         - name: device-plugin
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: config
           configMap:
             name: rdma-devices

--- a/images/k8s-rdma-shared-dev-plugin-ds.yaml
+++ b/images/k8s-rdma-shared-dev-plugin-ds.yaml
@@ -22,7 +22,11 @@ spec:
           privileged: true
         volumeMounts:
           - name: device-plugin
-            mountPath: /var/lib/kubelet/
+            mountPath: /var/lib/kubelet/device-plugins
+            readOnly: false
+          - name: plugins-registry
+            mountPath: /var/lib/kubelet/plugins_registry
+            readOnly: false
           - name: config
             mountPath: /k8s-rdma-shared-dev-plugin
           - name: devs
@@ -30,7 +34,10 @@ spec:
       volumes:
         - name: device-plugin
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: config
           configMap:
             name: rdma-devices


### PR DESCRIPTION
There is no need to mount the whole '/var/lib/kubelet/' directory into a pod. It's enough to mount only '/var/lib/kubelet/device-plugins' and '/var/lib/kubelet/plugins_registry' directories.