### PR TITLE
Remove "issm" device from required list

### DIFF
--- a/pkg/resources/rdma_device_spec.go
+++ b/pkg/resources/rdma_device_spec.go
@@ -16,7 +16,7 @@ type rdmaDeviceSpec struct {
 }
 
 // Required RDMA devices
-var requiredRdmaDevices = []string{"issm", "rdma_cm", "umad", "uverbs"}
+var requiredRdmaDevices = []string{"rdma_cm", "umad", "uverbs"}
 
 func NewRdmaDeviceSpec(rdmaDevs []string) types.RdmaDeviceSpec {
 	return &rdmaDeviceSpec{rdmaDevs: rdmaDevs}


### PR DESCRIPTION
"issm" devices should be created only if link type is InfiniBand. It's not required for Ethernet devices.