### PR TITLE
chore: fix docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN make clean && \
     make build
 
 FROM alpine:3.21.3
-RUN apk add --no-cache kmod=30-r3 hwdata-pci=0.370-r0
 COPY --from=builder /usr/src/k8s-rdma-shared-dp/build/k8s-rdma-shared-dp /bin/
 
 LABEL io.k8s.display-name="RDMA Shared Device Plugin"


### PR DESCRIPTION
Newer hwdata-pci and kmod available in base image

[2/2] STEP 2/5: RUN apk add --no-cache kmod=30-r3 hwdata-pci=0.370-r0 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz ERROR: unable to select packages:
  hwdata-pci-0.390-r0:
    breaks: world[hwdata-pci=0.370-r0]
  kmod-33-r2:
    breaks: world[kmod=30-r3]
Error: building at STEP "RUN apk add --no-cache kmod=30-r3 hwdata-pci=0.370-r0": while running runtime: exit status 2