### PR TITLE
Install hwdata-pci package in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN make clean && \
     make build
 
 FROM alpine:3.21.3
+RUN apk add --no-cache hwdata-pci=0.393-r0
 COPY --from=builder /usr/src/k8s-rdma-shared-dp/build/k8s-rdma-shared-dp /bin/
 
 LABEL io.k8s.display-name="RDMA Shared Device Plugin"


### PR DESCRIPTION
The alpine:3.21.3 image don't contain hwdata-pci package so failes to run in container.
`Error: error discovering host devices error getting PCI info: No pci-ids DB files found (and network fetch disabled)`