### PR TITLE
Add '--kubelet-root-dir' flag to configure the root directory of kubelet

### DIFF
--- a/cmd/k8s-rdma-shared-dp/main.go
+++ b/cmd/k8s-rdma-shared-dp/main.go
@@ -54,21 +54,21 @@ func printVersionString() string {
 	return fmt.Sprintf("k8s-rdma-shared-dev-plugin version:%s, commit:%s, date:%s", version, commit, date)
 }
 
-func main() {
+func parseFlags() (versionOpt bool, configFilePath, kubeletRootDir string, useCdi bool) {
 	// Init command line flags to clear vendor packages' flags, especially in init()
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
-
-	// add version flag
-	versionOpt := false
-	var configFilePath string
 	flag.BoolVar(&versionOpt, "version", false, "Show application version")
 	flag.BoolVar(&versionOpt, "v", false, "Show application version")
 	flag.StringVar(
 		&configFilePath, "config-file", resources.DefaultConfigFilePath, "path to device plugin config file")
-	useCdi := false
-	flag.BoolVar(&useCdi, "use-cdi", false,
-		"Use Container Device Interface to expose devices in containers")
+	flag.StringVar(&kubeletRootDir, "kubelet-root-dir", "/var/lib/kubelet", "root directory of kubelet")
+	flag.BoolVar(&useCdi, "use-cdi", false, "Use Container Device Interface to expose devices in containers")
 	flag.Parse()
+	return
+}
+
+func main() {
+	versionOpt, configFilePath, kubeletRootDir, useCdi := parseFlags()
 	if versionOpt {
 		fmt.Printf("%s\n", printVersionString())
 		return
@@ -80,7 +80,7 @@ func main() {
 
 	log.Println("Starting K8s RDMA Shared Device Plugin version=", version)
 
-	rm := resources.NewResourceManager(configFilePath, useCdi)
+	rm := resources.NewResourceManager(configFilePath, kubeletRootDir, useCdi)
 
 	log.Println("resource manager reading configs")
 	if err := rm.ReadConfig(); err != nil {

--- a/pkg/resources/resources_manager.go
+++ b/pkg/resources/resources_manager.go
@@ -39,6 +39,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"regexp"
 	"strconv"
 	"time"
@@ -54,6 +55,7 @@ import (
 const (
 	// General constants
 	DefaultConfigFilePath = "/k8s-rdma-shared-dev-plugin/config.json"
+	defaultKubeletRootDir = "/var/lib/kubelet"
 	kubeEndPoint          = "kubelet.sock"
 	socketSuffix          = "sock"
 	rdmaHcaResourcePrefix = "rdma"
@@ -71,15 +73,23 @@ const (
 )
 
 var (
-	activeSockDir     = "/var/lib/kubelet/plugins_registry"
-	deprecatedSockDir = "/var/lib/kubelet/device-plugins"
+	kubeletPluginRegistry    = "plugins_registry"
+	deprecatedPluginRegistry = "device-plugins"
 )
+
+func getActiveSockDir(kubeletRootDir string) string {
+	return path.Join(kubeletRootDir, kubeletPluginRegistry)
+}
+
+func getDeprecatedSockDir() string {
+	return path.Join(defaultKubeletRootDir, deprecatedPluginRegistry)
+}
 
 // resourceManager for plugin
 type resourceManager struct {
 	configFile             string
 	defaultResourcePrefix  string
-	socketSuffix           string
+	kubeletRootDir         string
 	watchMode              bool
 	configList             []*types.UserConfig
 	resourceServers        []types.ResourceServer
@@ -90,18 +100,12 @@ type resourceManager struct {
 	useCdi                 bool
 }
 
-func NewResourceManager(configFile string, useCdi bool) types.ResourceManager {
-	watcherMode := detectPluginWatchMode(activeSockDir)
-	if watcherMode {
-		fmt.Println("Using Kubelet Plugin Registry Mode")
-	} else {
-		fmt.Println("Using Deprecated Devie Plugin Registry Path")
-	}
+func NewResourceManager(configFile, kubeletRootDir string, useCdi bool) types.ResourceManager {
 	return &resourceManager{
 		configFile:            configFile,
+		watchMode:             detectPluginWatchMode(getActiveSockDir(kubeletRootDir)),
+		kubeletRootDir:        kubeletRootDir,
 		defaultResourcePrefix: rdmaHcaResourcePrefix,
-		socketSuffix:          socketSuffix,
-		watchMode:             watcherMode,
 		netlinkManager:        &netlinkManager{},
 		rds:                   NewRdmaDeviceSpec(requiredRdmaDevices),
 		useCdi:                useCdi,
@@ -244,7 +248,7 @@ func (rm *resourceManager) InitServers() error {
 				return err
 			}
 		}
-		rs, err := newResourceServer(config, filteredDevices, rm.watchMode, rm.socketSuffix, rm.useCdi)
+		rs, err := newResourceServer(config, filteredDevices, rm.kubeletRootDir, rm.watchMode, rm.useCdi)
 		if err != nil {
 			return err
 		}

--- a/pkg/resources/resources_manager_test.go
+++ b/pkg/resources/resources_manager_test.go
@@ -68,31 +68,21 @@ func (l *FakeLink) Type() string {
 
 var _ = Describe("ResourcesManger", func() {
 	Context("NewResourceManager", func() {
-		const activeSockDirBackUP = "/var/lib/kubelet/plugins_registry"
-
 		It("Resource Manager with watcher mode", func() {
 			fs := utils.FakeFilesystem{
-				Dirs: []string{activeSockDir[1:]},
+				Dirs: []string{kubeletPluginRegistry},
 			}
 			defer fs.Use()()
-			activeSockDir = path.Join(fs.RootDir, activeSockDirBackUP[1:])
-			defer func() {
-				activeSockDir = activeSockDirBackUP
-			}()
 
-			obj := NewResourceManager(DefaultConfigFilePath, false)
+			obj := NewResourceManager(DefaultConfigFilePath, fs.RootDir, false)
 			rm := obj.(*resourceManager)
 			Expect(rm.watchMode).To(Equal(true))
 		})
 		It("Resource Manager without watcher mode", func() {
 			fs := utils.FakeFilesystem{}
 			defer fs.Use()()
-			activeSockDir = path.Join(fs.RootDir, "noDir")
-			defer func() {
-				activeSockDir = activeSockDirBackUP
-			}()
 
-			obj := NewResourceManager(DefaultConfigFilePath, false)
+			obj := NewResourceManager(DefaultConfigFilePath, fs.RootDir, false)
 			rm := obj.(*resourceManager)
 			Expect(rm.watchMode).To(Equal(false))
 		})

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -42,6 +42,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+
 	"time"
 
 	"context"
@@ -67,15 +68,17 @@ type resourcesServerPort struct {
 }
 
 type resourceServer struct {
-	resourceName   string
-	watchMode      bool
-	socketName     string
-	socketPath     string
-	stopWatcher    chan bool
-	updateResource chan bool
-	health         chan *pluginapi.Device
-	rsConnector    types.ResourceServerPort
-	rdmaHcaMax     int
+	activeSockDir     string
+	deprecatedSockDir string
+	resourceName      string
+	watchMode         bool
+	socketName        string
+	socketPath        string
+	stopWatcher       chan bool
+	updateResource    chan bool
+	health            chan *pluginapi.Device
+	rsConnector       types.ResourceServerPort
+	rdmaHcaMax        int
 	// Mutex protects devs and deviceSpec
 	mutex           sync.RWMutex
 	devs            []*pluginapi.Device
@@ -136,11 +139,21 @@ func (rsc *resourcesServerPort) GetClientConn(unixSocketPath string) (*grpc.Clie
 }
 
 // newResourceServer returns an initialized server
-func newResourceServer(config *types.UserConfig, devices []types.PciNetDevice, watcherMode bool,
-	socketSuffix string, useCdi bool) (types.ResourceServer, error) {
+func newResourceServer(
+	config *types.UserConfig, devices []types.PciNetDevice, kubeletRootDir string, watcherMode, useCdi bool,
+) (types.ResourceServer, error) {
 	var devs []*pluginapi.Device
 
+	activeSockDir := getActiveSockDir(kubeletRootDir)
+	deprecatedSockDir := getDeprecatedSockDir()
 	sockDir := activeSockDir
+
+	if watcherMode {
+		log.Printf("Using watch mode with socket directory: %s\n", activeSockDir)
+	} else {
+		sockDir = deprecatedSockDir
+		log.Printf("Using deprecated mode with socket directory: %s\n", deprecatedSockDir)
+	}
 
 	if config.RdmaHcaMax < 0 {
 		return nil, fmt.Errorf("error: Invalid value for rdmaHcaMax < 0: %d", config.RdmaHcaMax)
@@ -164,28 +177,26 @@ func newResourceServer(config *types.UserConfig, devices []types.PciNetDevice, w
 		log.Printf("Warning: no Rdma Devices were found for resource %s\n", config.ResourceName)
 	}
 
-	if !watcherMode {
-		sockDir = deprecatedSockDir
-	}
-
 	socketName := fmt.Sprintf("%s.%s", config.ResourceName, socketSuffix)
 
 	return &resourceServer{
-		resourceName:    fmt.Sprintf("%s/%s", config.ResourcePrefix, config.ResourceName),
-		socketName:      socketName,
-		socketPath:      filepath.Join(sockDir, socketName),
-		watchMode:       watcherMode,
-		devs:            devs,
-		deviceSpec:      deviceSpec,
-		stopWatcher:     make(chan bool),
-		updateResource:  make(chan bool, 1),
-		health:          make(chan *pluginapi.Device),
-		rsConnector:     &resourcesServerPort{},
-		rdmaHcaMax:      config.RdmaHcaMax,
-		pciDevices:      devices,
-		useCdi:          useCdi,
-		cdi:             cdi.New(),
-		cdiResourceName: config.ResourceName,
+		activeSockDir:     activeSockDir,
+		deprecatedSockDir: deprecatedSockDir,
+		resourceName:      fmt.Sprintf("%s/%s", config.ResourcePrefix, config.ResourceName),
+		socketName:        socketName,
+		socketPath:        filepath.Join(sockDir, socketName),
+		watchMode:         watcherMode,
+		devs:              devs,
+		deviceSpec:        deviceSpec,
+		stopWatcher:       make(chan bool),
+		updateResource:    make(chan bool, 1),
+		health:            make(chan *pluginapi.Device),
+		rsConnector:       &resourcesServerPort{},
+		rdmaHcaMax:        config.RdmaHcaMax,
+		pciDevices:        devices,
+		useCdi:            useCdi,
+		cdi:               cdi.New(),
+		cdiResourceName:   config.ResourceName,
 	}, nil
 }
 
@@ -291,7 +302,7 @@ func (rs *resourceServer) Watch() {
 
 // Register registers the device plugin for the given resourceName with Kubelet.
 func (rs *resourceServer) register() error {
-	kubeletEndpoint := filepath.Join(deprecatedSockDir, kubeEndPoint)
+	kubeletEndpoint := filepath.Join(rs.deprecatedSockDir, kubeEndPoint)
 	conn, err := rs.rsConnector.GetClientConn(kubeletEndpoint)
 	if err != nil {
 		return err
@@ -438,7 +449,7 @@ func (rs *resourceServer) GetInfo(_ context.Context, _ *registerapi.InfoRequest)
 	pluginInfoResponse := &registerapi.PluginInfo{
 		Type:              registerapi.DevicePlugin,
 		Name:              rs.resourceName,
-		Endpoint:          filepath.Join(activeSockDir, rs.socketName),
+		Endpoint:          filepath.Join(rs.activeSockDir, rs.socketName),
 		SupportedVersions: []string{"v1alpha1", "v1beta1"},
 	}
 	return pluginInfoResponse, nil

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -60,6 +60,11 @@ const (
 	fakeNetDevicePath = "sys/class/net/ib0/"
 )
 
+var (
+	activeSockDir     = "/var/lib/kubelet/plugins_registry"
+	deprecatedSockDir = "/var/lib/kubelet/device-plugins"
+)
+
 type devPluginListAndWatchServerMock struct {
 	grpc.ServerStream
 	devices []*pluginapi.Device
@@ -92,11 +97,12 @@ var _ = Describe("resourceServer tests", func() {
 			}
 			defer fs.Use()()
 			conf := &types.UserConfig{ResourceName: "test_server", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", true, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
 			Expect(rs.resourceName).To(Equal("rdma/test_server"))
-			Expect(rs.socketName).To(Equal("test_server.socket"))
+			Expect(rs.socketName).To(Equal("test_server.sock"))
+			Expect(rs.socketPath).To(Equal(path.Join(activeSockDir, "test_server.sock")))
 			Expect(rs.watchMode).To(Equal(true))
 			Expect(len(rs.devs)).To(Equal(100))
 		})
@@ -107,11 +113,12 @@ var _ = Describe("resourceServer tests", func() {
 			}
 			defer fs.Use()()
 			conf := &types.UserConfig{ResourceName: "test_server", ResourcePrefix: "rdma", RdmaHcaMax: 0}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", true, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
 			Expect(rs.resourceName).To(Equal("rdma/test_server"))
-			Expect(rs.socketName).To(Equal("test_server.socket"))
+			Expect(rs.socketName).To(Equal("test_server.sock"))
+			Expect(rs.socketPath).To(Equal(path.Join(activeSockDir, "test_server.sock")))
 			Expect(rs.watchMode).To(Equal(true))
 			Expect(len(rs.devs)).To(Equal(0))
 		})
@@ -126,11 +133,12 @@ var _ = Describe("resourceServer tests", func() {
 			fakePciDevice.On("GetRdmaSpec").Return([]*pluginapi.DeviceSpec{})
 			fakePciDevice.On("GetPciAddr").Return("0000:02:00.0")
 			deviceList := []types.PciNetDevice{fakePciDevice}
-			obj, err := newResourceServer(conf, deviceList, true, "socket", false)
+			obj, err := newResourceServer(conf, deviceList, "/var/lib/kubelet", true, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
 			Expect(rs.resourceName).To(Equal("rdma/test_server"))
-			Expect(rs.socketName).To(Equal("test_server.socket"))
+			Expect(rs.socketName).To(Equal("test_server.sock"))
+			Expect(rs.socketPath).To(Equal(path.Join(activeSockDir, "test_server.sock")))
 			Expect(rs.watchMode).To(Equal(true))
 			Expect(len(rs.devs)).To(Equal(0))
 		})
@@ -141,11 +149,12 @@ var _ = Describe("resourceServer tests", func() {
 			}
 			defer fs.Use()()
 			conf := &types.UserConfig{ResourceName: "test_server", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-			obj, err := newResourceServer(conf, fakeDeviceList, false, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", false, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
 			Expect(rs.resourceName).To(Equal("rdma/test_server"))
-			Expect(rs.socketName).To(Equal("test_server.socket"))
+			Expect(rs.socketName).To(Equal("test_server.sock"))
+			Expect(rs.socketPath).To(Equal(path.Join(deprecatedSockDir, "test_server.sock")))
 			Expect(rs.watchMode).To(Equal(false))
 			Expect(len(rs.devs)).To(Equal(100))
 		})
@@ -156,17 +165,18 @@ var _ = Describe("resourceServer tests", func() {
 			}
 			defer fs.Use()()
 			conf := &types.UserConfig{ResourceName: "test_server", ResourcePrefix: "rdma", RdmaHcaMax: 0}
-			obj, err := newResourceServer(conf, fakeDeviceList, false, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", false, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
 			Expect(rs.resourceName).To(Equal("rdma/test_server"))
-			Expect(rs.socketName).To(Equal("test_server.socket"))
+			Expect(rs.socketName).To(Equal("test_server.sock"))
+			Expect(rs.socketPath).To(Equal(path.Join(deprecatedSockDir, "test_server.sock")))
 			Expect(rs.watchMode).To(Equal(false))
 			Expect(len(rs.devs)).To(Equal(0))
 		})
 		It("server with plugin with invalid max number of resources", func() {
 			conf := &types.UserConfig{ResourceName: "test_server", ResourcePrefix: "rdma", RdmaHcaMax: -100}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", true, false)
 			Expect(err).To(HaveOccurred())
 			Expect(obj).To(BeNil())
 		})
@@ -399,7 +409,7 @@ var _ = Describe("resourceServer tests", func() {
 			}
 			defer fs.Use()()
 			conf := &types.UserConfig{RdmaHcaMax: 100, ResourcePrefix: "rdma", ResourceName: "fake"}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "fake", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", true, false)
 			Expect(err).ToNot(HaveOccurred())
 
 			rs := obj.(*resourceServer)
@@ -430,7 +440,7 @@ var _ = Describe("resourceServer tests", func() {
 			}
 			defer fs.Use()()
 			conf := &types.UserConfig{RdmaHcaMax: 1, ResourcePrefix: "rdma", ResourceName: "fake"}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "fake", true)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", true, true)
 			Expect(err).ToNot(HaveOccurred())
 
 			cdi := &cdiMocks.CDI{}
@@ -485,7 +495,7 @@ var _ = Describe("resourceServer tests", func() {
 	})
 	Context("GetInfo", func() {
 		It("GetInfo of plugin", func() {
-			rs := resourceServer{resourceName: "fake", socketName: "fake.sock"}
+			rs := resourceServer{activeSockDir: activeSockDir, resourceName: "fake", socketName: "fake.sock"}
 			resp, err := rs.GetInfo(context.TODO(), nil)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.Type).To(Equal(registerapi.DevicePlugin))
@@ -556,15 +566,17 @@ var _ = Describe("resourceServer tests", func() {
 	})
 	DescribeTable("registering with Kubelet",
 		func(shouldRunServer, shouldEnablePluginWatch, shouldServerFail, shouldFail bool) {
-			fs := &utils.FakeFilesystem{}
+			fs := &utils.FakeFilesystem{
+				Dirs: []string{kubeletPluginRegistry, deprecatedPluginRegistry},
+			}
 			defer fs.Use()()
 
 			// Use faked dir as socket dir
 			activeSockDirBackup := activeSockDir
 			deprecatedSockDirBackup := deprecatedSockDir
 
-			deprecatedSockDir = fs.RootDir
-			activeSockDir = fs.RootDir
+			deprecatedSockDir = path.Join(fs.RootDir, deprecatedPluginRegistry)
+			activeSockDir = path.Join(fs.RootDir, kubeletPluginRegistry)
 
 			defer func() {
 				deprecatedSockDir = deprecatedSockDirBackup
@@ -572,12 +584,20 @@ var _ = Describe("resourceServer tests", func() {
 			}()
 
 			conf := &types.UserConfig{ResourceName: "fake_test", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, fs.RootDir, shouldEnablePluginWatch, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
+			if !shouldEnablePluginWatch {
+				rs.deprecatedSockDir = deprecatedSockDir
+				rs.socketPath = path.Join(deprecatedSockDir, rs.socketName)
+			}
 
-			registrationServer := createFakeRegistrationServer(deprecatedSockDir,
-				"fake_test.socket", shouldServerFail, shouldEnablePluginWatch)
+			registrationSockDir := deprecatedSockDir
+			if shouldEnablePluginWatch {
+				registrationSockDir = activeSockDir
+			}
+			registrationServer := createFakeRegistrationServer(registrationSockDir,
+				"fake_test.sock", shouldServerFail, shouldEnablePluginWatch)
 
 			if shouldRunServer {
 				if shouldEnablePluginWatch {
@@ -623,7 +643,9 @@ var _ = Describe("resourceServer tests", func() {
 			selectors := &types.Selectors{}
 			err := json.Unmarshal([]byte(`{"deviceIDs": ["fakeid"]}`), selectors)
 			Expect(err).NotTo(HaveOccurred())
-			fs = &utils.FakeFilesystem{}
+			fs = &utils.FakeFilesystem{
+				Dirs: []string{kubeletPluginRegistry, deprecatedPluginRegistry},
+			}
 		})
 		AfterEach(func() {
 			activeSockDir = activeSockDirBackup
@@ -633,15 +655,17 @@ var _ = Describe("resourceServer tests", func() {
 			It("should not fail and messages should be received on the channels without watcher mode", func() {
 				defer fs.Use()()
 				// Use faked dir as socket dir
-				deprecatedSockDir = fs.RootDir
+				deprecatedSockDir = path.Join(fs.RootDir, deprecatedPluginRegistry)
 
 				conf := &types.UserConfig{ResourceName: "fakename", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-				obj, err := newResourceServer(conf, fakeDeviceList, false, "socket", false)
+				obj, err := newResourceServer(conf, fakeDeviceList, fs.RootDir, false, false)
 				Expect(err).ToNot(HaveOccurred())
 				rs := obj.(*resourceServer)
+				rs.deprecatedSockDir = deprecatedSockDir
+				rs.socketPath = path.Join(deprecatedSockDir, rs.socketName)
 
 				registrationServer := createFakeRegistrationServer(deprecatedSockDir,
-					"fakename.socket", false, false)
+					"fakename.sock", false, false)
 				registrationServer.start()
 				defer registrationServer.stop()
 
@@ -662,15 +686,15 @@ var _ = Describe("resourceServer tests", func() {
 			It("should not fail and messages should be received on the channels with watcher mode", func() {
 				defer fs.Use()()
 				// Use faked dir as socket dir
-				activeSockDir = fs.RootDir
+				activeSockDir = path.Join(fs.RootDir, kubeletPluginRegistry)
 
 				conf := &types.UserConfig{ResourceName: "fakename", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-				obj, err := newResourceServer(conf, fakeDeviceList, true, "socket", false)
+				obj, err := newResourceServer(conf, fakeDeviceList, fs.RootDir, true, false)
 				Expect(err).ToNot(HaveOccurred())
 				rs := obj.(*resourceServer)
 
 				registrationServer := createFakeRegistrationServer(activeSockDir,
-					"fakename.socket", false, true)
+					"fakename.sock", false, true)
 
 				err = rs.Start()
 				Expect(err).NotTo(HaveOccurred())
@@ -692,15 +716,17 @@ var _ = Describe("resourceServer tests", func() {
 			It("should not fail and messages should be received on the channels", func() {
 				defer fs.Use()()
 				// Use faked dir as socket dir
-				deprecatedSockDir = fs.RootDir
+				deprecatedSockDir = path.Join(fs.RootDir, deprecatedPluginRegistry)
 
 				conf := &types.UserConfig{ResourceName: "fakename", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-				obj, err := newResourceServer(conf, fakeDeviceList, false, "socket", false)
+				obj, err := newResourceServer(conf, fakeDeviceList, fs.RootDir, false, false)
 				Expect(err).ToNot(HaveOccurred())
 				rs := obj.(*resourceServer)
+				rs.deprecatedSockDir = deprecatedSockDir
+				rs.socketPath = path.Join(deprecatedSockDir, rs.socketName)
 
 				registrationServer := createFakeRegistrationServer(deprecatedSockDir,
-					"fakename.socket", false, false)
+					"fakename.sock", false, false)
 				registrationServer.start()
 				defer registrationServer.stop()
 
@@ -724,7 +750,7 @@ var _ = Describe("resourceServer tests", func() {
 	DescribeTable("allocating",
 		func(req *pluginapi.AllocateRequest, expectedRespLength int, shouldFail bool) {
 			conf := &types.UserConfig{ResourceName: "fakename", ResourcePrefix: "rdma", RdmaHcaMax: 100}
-			obj, err := newResourceServer(conf, fakeDeviceList, true, "socket", false)
+			obj, err := newResourceServer(conf, fakeDeviceList, "/var/lib/kubelet", true, false)
 			Expect(err).ToNot(HaveOccurred())
 			rs := obj.(*resourceServer)
 


### PR DESCRIPTION
As a part of https://github.com/Mellanox/k8s-rdma-shared-dev-plugin/pull/111, and fix https://github.com/Mellanox/k8s-rdma-shared-dev-plugin/issues/96