### PR TITLE
feat: Add option to specify custom kubelet socket path

### DIFF
--- a/pkg/resources/resources_manager.go
+++ b/pkg/resources/resources_manager.go
@@ -51,6 +51,14 @@ import (
 	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/utils"
 )
 
+// getSocketDir returns the socket directory path, checking environment variable first
+func getSocketDir(defaultPath string) string {
+	if envPath := os.Getenv("DP_SOCK_PATH"); envPath != "" {
+		return envPath
+	}
+	return defaultPath
+}
+
 const (
 	// General constants
 	DefaultConfigFilePath = "/k8s-rdma-shared-dev-plugin/config.json"
@@ -71,8 +79,8 @@ const (
 )
 
 var (
-	activeSockDir     = "/var/lib/kubelet/plugins_registry"
-	deprecatedSockDir = "/var/lib/kubelet/device-plugins"
+	activeSockDir     = getSocketDir("/var/lib/kubelet/plugins_registry")
+	deprecatedSockDir = getSocketDir("/var/lib/kubelet/device-plugins")
 )
 
 // resourceManager for plugin

--- a/pkg/resources/resources_manager_test.go
+++ b/pkg/resources/resources_manager_test.go
@@ -97,6 +97,31 @@ var _ = Describe("ResourcesManger", func() {
 			Expect(rm.watchMode).To(Equal(false))
 		})
 	})
+	Context("getSocketDir", func() {
+		It("returns environment variable when DP_SOCK_PATH is set", func() {
+			customPath := "/custom/socket/path"
+			os.Setenv("DP_SOCK_PATH", customPath)
+			defer os.Unsetenv("DP_SOCK_PATH")
+
+			result := getSocketDir("/default/path")
+			Expect(result).To(Equal(customPath))
+		})
+		It("returns default path when DP_SOCK_PATH is not set", func() {
+			os.Unsetenv("DP_SOCK_PATH")
+			defaultPath := "/default/path"
+
+			result := getSocketDir(defaultPath)
+			Expect(result).To(Equal(defaultPath))
+		})
+		It("returns environment variable even when it's empty string", func() {
+			os.Setenv("DP_SOCK_PATH", "")
+			defer os.Unsetenv("DP_SOCK_PATH")
+			defaultPath := "/default/path"
+
+			result := getSocketDir(defaultPath)
+			Expect(result).To(Equal(defaultPath))
+		})
+	})
 	//nolint:dupl
 	Context("ReadConfig", func() {
 		It("Read valid config file with non default periodic update", func() {


### PR DESCRIPTION
Add the option to specify a custom socket path. In internal systems we have custom kubelet paths and would like to use the rdma device plugin without forking it. 