### PR TITLE
fix: restart plugin after ListAndWatch closes

### DIFF
--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -76,8 +76,9 @@ type resourceServer struct {
 	health         chan *pluginapi.Device
 	rsConnector    types.ResourceServerPort
 	rdmaHcaMax     int
-	// Mutex protects devs and deviceSpec
+	// Mutex protects lifecycle state, devs, and deviceSpec
 	mutex           sync.RWMutex
+	stopping        bool
 	devs            []*pluginapi.Device
 	deviceSpec      []*pluginapi.DeviceSpec
 	pciDevices      []types.PciNetDevice
@@ -198,6 +199,7 @@ func detectPluginWatchMode(sockDir string) bool {
 
 // Start starts the gRPC server of the device plugin
 func (rs *resourceServer) Start() error {
+	rs.setStopping(false)
 	_ = rs.cleanup()
 	log.Printf("starting %s device plugin endpoint at: %s\n", rs.resourceName, rs.socketName)
 	rs.rsConnector.CreateServer()
@@ -235,6 +237,7 @@ func (rs *resourceServer) Start() error {
 // Stop stops the gRPC server
 func (rs *resourceServer) Stop() error {
 	log.Printf("stopping %s device plugin server...", rs.resourceName)
+	rs.setStopping(true)
 	if rs.rsConnector == nil || rs.rsConnector.GetServer() == nil {
 		return nil
 	}
@@ -261,6 +264,29 @@ func (rs *resourceServer) Restart() error {
 	rs.rsConnector.DeleteServer()
 
 	return rs.Start()
+}
+
+func (rs *resourceServer) setStopping(stopping bool) {
+	rs.mutex.Lock()
+	defer rs.mutex.Unlock()
+	rs.stopping = stopping
+}
+
+func (rs *resourceServer) isStopping() bool {
+	rs.mutex.RLock()
+	defer rs.mutex.RUnlock()
+	return rs.stopping
+}
+
+func (rs *resourceServer) restartAfterListAndWatchClose() {
+	if rs.isStopping() {
+		return
+	}
+	go func() {
+		if err := rs.Restart(); err != nil {
+			log.Printf("error: unable to restart server after ListAndWatch stream closed: %v", err)
+		}
+	}()
 }
 
 // Watch for Kubelet socket file; if not present restart server
@@ -330,6 +356,7 @@ func (rs *resourceServer) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlu
 		select {
 		case <-s.Context().Done():
 			log.Printf("ListAndWatch stream close: %v", s.Context().Err())
+			rs.restartAfterListAndWatchClose()
 			return nil
 		case d := <-rs.health:
 			// FIXME: there is no way to recover from the Unhealthy state.

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -459,6 +459,37 @@ var _ = Describe("resourceServer tests", func() {
 			err := rs.ListAndWatch(nil, s)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("Restart server when ListAndWatch stream is closed unexpectedly", func() {
+			grpcServer := grpc.NewServer([]grpc.ServerOption{}...)
+			restarted := make(chan struct{})
+			rsc := mocks.NewMockResourceServerPort(GinkgoT())
+			rsc.On("GetServer").Return(grpcServer)
+			rsc.On("Stop").Return()
+			rsc.On("DeleteServer").Return()
+			rsc.On("CreateServer").Return()
+			rsc.On("Listen", "unix", "fake.sock").Return(nil, nil)
+			rsc.On("Serve", mock.Anything).Return()
+			rsc.On("GetClientConn", "fake.sock").Return(nil, nil)
+			rsc.On("Close", mock.Anything).Run(func(_ mock.Arguments) {
+				close(restarted)
+			}).Return()
+
+			rs := resourceServer{
+				resourceName: "fake",
+				socketName:   "fake.sock",
+				socketPath:   "fake.sock",
+				rsConnector:  rsc,
+			}
+			s := &devPluginListAndWatchServerMock{}
+			ctx, cancel := context.WithCancel(context.Background())
+			s.SetContext(ctx)
+			cancel()
+
+			err := rs.ListAndWatch(nil, s)
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(restarted).Should(BeClosed())
+			rsc.AssertExpectations(testCallsAssertionReporter)
+		})
 	})
 	Context("Allocate", func() {
 		It("Allocate resource", func() {


### PR DESCRIPTION
Summary:
- restart the device plugin server after a `ListAndWatch` stream closes, so kubelet can rediscover/register the endpoint instead of leaving it unhealthy
- track intentional server shutdowns so `Stop()` does not trigger a self-restart through a canceled stream
- add coverage for the stream-close restart path

Verification:
- `GOOS=linux GOARCH=amd64 go test -c ./pkg/resources -o <temp>`
- `git diff --check`

I also tried `go test ./pkg/resources -run TestResources -count=1` on Windows, but the package does not compile locally before reaching the tests because `pkg/resources/resources_manager.go` references the Linux-only `netlink.RdmaSystemGetNetnsMode` symbol. The Linux compile-only check above passed.

Signed-off-by: Omri Ben Zvi <omribz156@gmail.com>

Closes #255

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before posting.