### PR TITLE
fix: refresh CDI devices during resource updates

### DIFF
--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -485,7 +485,7 @@ func (rs *resourceServer) UpdateDevices(devices []types.PciNetDevice) {
 	deviceSpec := getDevicesSpec(devices)
 
 	// If not devices not changed skip
-	if !devicesChanged(rs.deviceSpec, deviceSpec) {
+	if !devicesChanged(rs.deviceSpec, deviceSpec) && (!rs.useCdi || !pciDevicesChanged(rs.pciDevices, devices)) {
 		log.Printf("no changes to devices for \"%s\"", rs.resourceName)
 		log.Printf("exposing \"%d\" devices", len(rs.devs))
 		return
@@ -538,6 +538,23 @@ func devicesChanged(deviceList, newDeviceList []*pluginapi.DeviceSpec) bool {
 		}
 	}
 
+	return false
+}
+
+// pciDevicesChanged compares the PCI addresses used in CDI device names.
+func pciDevicesChanged(devices, newDevices []types.PciNetDevice) bool {
+	if len(devices) != len(newDevices) {
+		return true
+	}
+	addresses := make(map[string]struct{}, len(devices))
+	for _, device := range devices {
+		addresses[device.GetPciAddr()] = struct{}{}
+	}
+	for _, device := range newDevices {
+		if _, exists := addresses[device.GetPciAddr()]; !exists {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/resources/server.go
+++ b/pkg/resources/server.go
@@ -79,7 +79,7 @@ type resourceServer struct {
 	health            chan *pluginapi.Device
 	rsConnector       types.ResourceServerPort
 	rdmaHcaMax        int
-	// Mutex protects devs and deviceSpec
+	// Mutex protects devs, deviceSpec and pciDevices
 	mutex           sync.RWMutex
 	devs            []*pluginapi.Device
 	deviceSpec      []*pluginapi.DeviceSpec
@@ -329,9 +329,7 @@ func (rs *resourceServer) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlu
 		return err
 	}
 
-	rs.mutex.RLock()
 	err := rs.updateCDISpec()
-	rs.mutex.RUnlock()
 	if err != nil {
 		log.Printf("cannot update CDI specs: %v", err)
 		return err
@@ -363,6 +361,9 @@ func (rs *resourceServer) ListAndWatch(_ *pluginapi.Empty, s pluginapi.DevicePlu
 }
 
 func (rs *resourceServer) updateCDISpec() error {
+	rs.mutex.RLock()
+	defer rs.mutex.RUnlock()
+
 	// check if CDI mode is enabled
 	if !rs.useCdi {
 		return nil
@@ -491,6 +492,7 @@ func (rs *resourceServer) UpdateDevices(devices []types.PciNetDevice) {
 	}
 
 	rs.deviceSpec = deviceSpec
+	rs.pciDevices = devices
 	needUpdate = true
 
 	// In case no RDMA resource report 0 resources

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -42,6 +42,7 @@ import (
 	"sync"
 	"time"
 
+	cdiImpl "github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/cdi"
 	cdiMocks "github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/cdi/mocks"
 	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/types"
 	"github.com/Mellanox/k8s-rdma-shared-dev-plugin/pkg/types/mocks"
@@ -521,6 +522,77 @@ var _ = Describe("resourceServer tests", func() {
 		})
 	})
 	Context("UpdateDevices", func() {
+		initialCDIDevices := []types.PciNetDevice{&pciNetDevice{
+			pciAddress: "0000:02:00.0",
+			rdmaSpec:   fakeDeviceSpec,
+		}}
+		replacementDevices := []types.PciNetDevice{&pciNetDevice{
+			pciAddress: "0000:03:00.0",
+			rdmaSpec:   []*pluginapi.DeviceSpec{{HostPath: "replacement", ContainerPath: "replacement"}},
+		}}
+		DescribeTable("refreshes CDI devices",
+			func(initialDevices, updatedDevices []types.PciNetDevice) {
+				rs := &resourceServer{
+					updateResource:  make(chan bool, 1),
+					rdmaHcaMax:      10,
+					deviceSpec:      getDevicesSpec(initialDevices),
+					pciDevices:      initialDevices,
+					useCdi:          true,
+					cdiResourceName: "test_pool",
+				}
+				cdi := &cdiMocks.CDI{}
+				cdi.On("CreateCDISpec", cdiResourcePrefix, cdiResourceKind, "test_pool", updatedDevices).Return(nil)
+				rs.cdi = cdi
+
+				rs.UpdateDevices(updatedDevices)
+				Expect(len(rs.updateResource)).To(Equal(1))
+				<-rs.updateResource
+				rs.UpdateDevices(updatedDevices)
+				Expect(rs.updateResource).ToNot(Receive())
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				stream := &devPluginListAndWatchServerMock{ctx: ctx}
+				Expect(rs.ListAndWatch(nil, stream)).To(Succeed())
+				cdi.AssertExpectations(GinkgoT())
+				rs.cdi = cdiImpl.New()
+				response, err := rs.Allocate(context.Background(), &pluginapi.AllocateRequest{
+					ContainerRequests: []*pluginapi.ContainerAllocateRequest{{DevicesIDs: []string{"0"}}},
+				})
+				if len(updatedDevices) == 0 {
+					Expect(err).To(MatchError(ContainSubstring("devices list is empty")))
+					Expect(response).To(BeNil())
+				} else {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(response.ContainerResponses[0].Annotations).To(Equal(map[string]string{
+						"cdi.k8s.io/nvidia.com_net-rdma": "nvidia.com/net-rdma=" + updatedDevices[0].GetPciAddr(),
+					}))
+				}
+			},
+			Entry("when an empty pool gains a device", []types.PciNetDevice{}, initialCDIDevices),
+			Entry("when the pool becomes empty", initialCDIDevices, []types.PciNetDevice{}),
+			Entry("when a device is replaced", initialCDIDevices, replacementDevices),
+		)
+		It("synchronizes CDI reads with device updates", func() {
+			cdi := &cdiMocks.CDI{}
+			cdi.On("CreateCDISpec", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			rs := &resourceServer{useCdi: true, cdi: cdi, updateResource: make(chan bool, 100)}
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := 0; i < 100; i++ {
+					if i%2 == 0 {
+						rs.UpdateDevices(fakeDeviceList)
+					} else {
+						rs.UpdateDevices(replacementDevices)
+					}
+				}
+			}()
+			for i := 0; i < 100; i++ {
+				Expect(rs.updateCDISpec()).To(Succeed())
+			}
+			wg.Wait()
+		})
 		It("should receive signal of updating resource", func() {
 			rs := &resourceServer{
 				updateResource: make(chan bool),

--- a/pkg/resources/server_test.go
+++ b/pkg/resources/server_test.go
@@ -571,7 +571,22 @@ var _ = Describe("resourceServer tests", func() {
 			Entry("when an empty pool gains a device", []types.PciNetDevice{}, initialCDIDevices),
 			Entry("when the pool becomes empty", initialCDIDevices, []types.PciNetDevice{}),
 			Entry("when a device is replaced", initialCDIDevices, replacementDevices),
+			Entry("when only the PCI address changes", initialCDIDevices, []types.PciNetDevice{&pciNetDevice{
+				pciAddress: "0000:03:00.0",
+				rdmaSpec:   fakeDeviceSpec,
+			}}),
 		)
+		It("does not update CDI devices when their order changes", func() {
+			devices := append(append([]types.PciNetDevice{}, initialCDIDevices...), replacementDevices...)
+			rs := &resourceServer{
+				updateResource: make(chan bool, 1),
+				deviceSpec:     getDevicesSpec(devices),
+				pciDevices:     devices,
+				useCdi:         true,
+			}
+			rs.UpdateDevices([]types.PciNetDevice{devices[1], devices[0]})
+			Expect(rs.updateResource).ToNot(Receive())
+		})
 		It("synchronizes CDI reads with device updates", func() {
 			cdi := &cdiMocks.CDI{}
 			cdi.On("CreateCDISpec", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
fix: keep CDI devices in sync with resource updates

Periodic device discovery updates the advertised resources and device
specs, but leaves the PCI device list used by CDI unchanged. A pool that
starts empty can therefore advertise resources after discovering a
device while CDI allocation still fails with `devices list is empty`.
Removed or replaced devices can also remain in CDI specs and annotations.

Refresh the PCI device list alongside the device specs and protect CDI
spec generation with the resource mutex. In CDI mode, also detect PCI
address changes when the RDMA device paths stay the same.

Regression coverage checks additions, removals, replacements (including
PCI-only changes), unchanged or reordered updates, and concurrent CDI
reads. The original device-change cases and the PCI-only follow-up each
failed before their corresponding fixes. Allocation checks use the real CDI
annotation implementation; spec-generation checks verify the device list
passed to the CDI writer.

Validation:
- `go test -race ./... -count=1`
- `make lint` (0 issues)
- `make build`

These checks run on CPU without an RDMA device. No container-runtime or
physical-device hotplug end-to-end test was run.

External Mellanox CI build 435 fails during test-host preparation:
`rdma system set netns shared` reports `Device or resource busy`, then
the IPoIB setup exits before running the plugin checks. See the
[CI console](https://nvidia-nbu-ci-logs.s3.us-east-2.amazonaws.com/K8S_RDMA_SHARED_DEV_PLUGIN/435/consoleText).
